### PR TITLE
fixes diagonal obstruction check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Documentation:
 Layout/CommentIndentation:
   Enabled: false
 
-Layout/Tab:
+Metrics/AbcSize:
   Enabled: false
 
 Metrics/LineLength:
@@ -21,6 +21,9 @@ Metrics/LineLength:
 
 Metrics/MethodLength:
   Max: 100
+
+Metrics/BlockLength:
+  Enabled: false
 
 Style/EmptyMethod:
   Enabled: false

--- a/app/services/pieces/move_to.rb
+++ b/app/services/pieces/move_to.rb
@@ -12,12 +12,9 @@ module Pieces
     def call
       if game.square_occupied?(new_column, new_row)
         new_piece = game.get_piece(new_column, new_row)
-        if new_piece.player_color != piece.player_color
-          piece.update_attributes(column: new_column, row: new_row)
-          new_piece.update_attributes(captured: true)
-        else
-          return false
-        end
+        return false unless new_piece.player_color != piece.player_color
+        piece.update_attributes(column: new_column, row: new_row)
+        new_piece.update_attributes(captured: true)
       else
         piece.update_attributes(column: new_column, row: new_row)
       end

--- a/app/services/pieces/obstruction.rb
+++ b/app/services/pieces/obstruction.rb
@@ -51,12 +51,17 @@ module Pieces
     end
 
     def diagnol_obstruction
+      row_delta = 0
+      column_delta = 0
       (row_start...row_end).each do |row|
+        row_delta += 1
         (column_start...column_end).each do |column|
-          if row == column
+          column_delta += 1
+          if row_delta == column_delta
             return true if game.square_occupied?(column, row)
           end
         end
+        column_delta = 0
       end
       false
     end

--- a/app/services/pieces/obstruction.rb
+++ b/app/services/pieces/obstruction.rb
@@ -21,7 +21,7 @@ module Pieces
     attr_accessor :game, :piece, :current_row, :current_column, :new_row, :new_column
 
     def column_start
-      [current_column, new_column].min
+      [current_column, new_column].min + 1
     end
 
     def row_start
@@ -37,7 +37,7 @@ module Pieces
     end
 
     def horizontal_obstruction
-      (column_start + 1...column_end).each do |column|
+      (column_start...column_end).each do |column|
         return true if game.square_occupied?(column, current_row)
       end
       false
@@ -55,14 +55,14 @@ module Pieces
       if down_right == true
         (row_start...row_end).each do |row|
           column_delta = row - row_start
-          column = column_start + 1 + column_delta
+          column = column_start + column_delta
           return true if game.square_occupied?(column, row)
         end
       # diagonal going down and left or up and right
       else
         (row_start...row_end).each do |row|
           column_delta = row_start - row
-          column = column_start - 1 + column_delta
+          column = column_end - 1 + column_delta
           return true if game.square_occupied?(column, row)
         end
       end
@@ -72,7 +72,7 @@ module Pieces
     def down_right
       if current_column < new_column && current_row < new_row
         true
-      elsif current_column > new_column && current_column > new_row
+      elsif current_column > new_column && current_row > new_row
         true
       else
         false

--- a/app/services/pieces/obstruction.rb
+++ b/app/services/pieces/obstruction.rb
@@ -21,7 +21,7 @@ module Pieces
     attr_accessor :game, :piece, :current_row, :current_column, :new_row, :new_column
 
     def column_start
-      [current_column, new_column].min + 1
+      [current_column, new_column].min
     end
 
     def row_start
@@ -37,7 +37,7 @@ module Pieces
     end
 
     def horizontal_obstruction
-      (column_start...column_end).each do |column|
+      (column_start + 1...column_end).each do |column|
         return true if game.square_occupied?(column, current_row)
       end
       false
@@ -51,19 +51,32 @@ module Pieces
     end
 
     def diagnol_obstruction
-      row_delta = 0
-      column_delta = 0
-      (row_start...row_end).each do |row|
-        row_delta += 1
-        (column_start...column_end).each do |column|
-          column_delta += 1
-          if row_delta == column_delta
-            return true if game.square_occupied?(column, row)
-          end
+      # diagonal going down and right or going up and going left
+      if down_right == true
+        (row_start...row_end).each do |row|
+          column_delta = row - row_start
+          column = column_start + 1 + column_delta
+          return true if game.square_occupied?(column, row)
         end
-        column_delta = 0
+      # diagonal going down and left or up and right
+      else
+        (row_start...row_end).each do |row|
+          column_delta = row_start - row
+          column = column_start - 1 + column_delta
+          return true if game.square_occupied?(column, row)
+        end
       end
       false
+    end
+
+    def down_right
+      if current_column < new_column && current_row < new_row
+        true
+      elsif current_column > new_column && current_column > new_row
+        true
+      else
+        false
+      end
     end
   end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -15,13 +15,17 @@ RSpec.describe Piece, type: :model do
     end
 
     it 'Should detect vertical obstructions' do
-      obstruction = Pieces::Obstruction.call(piece3, column: 2, row: 0)
+      obstruction = Pieces::Obstruction.call(piece3, column: 2, row: 1)
       expect(obstruction).to eq(true)
     end
 
-    it 'Should detect diagnol obstructions' do
-      obstruction = Pieces::Obstruction.call(piece4, column: 0, row: 0)
+    it 'Should detect diagnol obstructions down and right' do
+      obstruction = Pieces::Obstruction.call(piece4, column: 1, row: 1)
       expect(obstruction).to eq(true)
+    end
+
+    it 'Should detect diagnol obstructions up and right' do
+      obstruction = Pieces::Obstruction.call(piece3, column: 4, row: 1)
     end
   end
 

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Piece, type: :model do
 
     it 'Should detect diagnol obstructions up and right' do
       obstruction = Pieces::Obstruction.call(piece3, column: 4, row: 1)
+      expect(obstruction).to eq(true)
     end
   end
 


### PR DESCRIPTION
Previous iterations either checked every square in the grid, only checked diagonals with matching row/column e.g ([1,1] or [2,2]), or checked diagonals in only 1 direction. New method checks which direction diagonal is going and then only checks diagonal squares along the path for pieces.